### PR TITLE
feature/x23

### DIFF
--- a/unpackaged/main/default/objects/Account/fields/new_field__c.field-meta.xml
+++ b/unpackaged/main/default/objects/Account/fields/new_field__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>new_field__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>new field</label>
+    <trackFeedHistory>false</trackFeedHistory>
+    <type>Checkbox</type>
+</CustomField>


### PR DESCRIPTION
This PR adds a new custom field to the Account object. Below is a detailed breakdown of the changes made in the new metadata file:

---

## 1. 
### `new_field__c.field-meta.xml`
**Change:**
- A new custom field named `new_field__c` has been created with the following specifications:
  - **fullName**: `new_field__c`
  - **label**: `new field`
  - **type**: `Checkbox`
  - **defaultValue**: `false`
  - **externalId**: `false`
  - **trackFeedHistory**: `false`

**Impact:**
- This field can be used to capture boolean values on records of the Account object. 
- As it is a checkbox field, it will default to false unless the user explicitly checks it.  
- If existing processes, validation rules, or workflows reference fields on the Account object, they may need to be reviewed to ensure they accommodate this new field.
- Developers and administrators should consider updating documentation and user interfaces where relevant to include this new checkbox field. 
- Testing should ensure that the field is correctly displayed and behaves as intended in UI forms, reports, and automation workflows.

---

## Summary
This PR introduces a single change focused on enhancing the Account object with a new boolean field. It is important to review integration tests and any related business logic impacted by this addition.